### PR TITLE
fix: Create table query fails if column is a reserved word

### DIFF
--- a/pg_transparent_alter_table/tat.py
+++ b/pg_transparent_alter_table/tat.py
@@ -174,7 +174,7 @@ class TAT(Helper):
         column_names = self.apply_move_column_commands(self.table['all_columns'].keys())
         attr = self.table['all_columns']
         columns = ',\n              '.join(
-            f'{col} {attr[col]["type"]}{attr[col]["collate"]}{attr[col]["not_null"]}{attr[col]["default"]}'
+            f'"{col}" {attr[col]["type"]}{attr[col]["collate"]}{attr[col]["not_null"]}{attr[col]["default"]}'
             for col in column_names
         )
         commands = [


### PR DESCRIPTION
This pull request addresses an issue where an ALTER TABLE statement fails if the table contains a column named after a SQL reserved word (e.g., "cast").

The failure occurs during the creation of a temporary table, which does not properly quote the reserved word in the column name, leading to a SQL syntax error. This change ensures that column names are correctly quoted in the temporary table creation query, allowing ALTER TABLE operations to complete successfully on such tables.

Example of a problematic table:
```sql
CREATE TABLE my_table (
  some_column TEXT,
  "cast" INTEGER
);
```